### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/gngdb/holo-nets.png?label=ready&title=Ready)](https://waffle.io/gngdb/holo-nets)
 # holo-nets
 
 Simple wrapper around Holoviews for training neural networks interactively and monitoring channels.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/gngdb/holo-nets

This was requested by a real person (user gngdb) on waffle.io, we're not trying to spam you.
